### PR TITLE
Using fromEmail from configuration for sending auth-related emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ env:
     - COOKIE_DOMAIN=mymachine
     - SESSION_KEY=test
     - PUBLIC_URL=http://localhost:9000
+    - API_VERSION=v1
+    - CT_REGISTER_MODE=auto
     - SPARKPOST_KEY=fakeSparkpostKey
     - FASTLY_APIKEY=foo
     - FASTLY_SERVICEID=bar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 22/01/2020
+- Add and use `fromEmail` field on oauth plugin configuration (inside each application) as the name of the sender for auth-related emails
+
 # 12/12/2019
 - Change callback URL logic so that priority is:
     - Query param
@@ -12,7 +15,7 @@
 - Add pagination to GET users
 
 # 01/12/2019
-- Fix regression where 3rd party auth users without email address would not be able to authenticate 
+- Fix regression where 3rd party auth users without email address would not be able to authenticate
 
 # 08/11/2019
 - Add healthcheck endpoint and readiness+liveliness checks to k8s config

--- a/app/src/migrations/init.js
+++ b/app/src/migrations/init.js
@@ -79,6 +79,7 @@ module.exports = async function init() {
                     logo: 'https://resourcewatch.org/static/images/logo-embed.png',
                     principalColor: '#c32d7b',
                     sendNotifications: true,
+                    emailSender: 'noreply@resourcewatch.org',
                     emailSenderName: 'RW API',
                     confirmUrlRedirect: 'http://resourcewatch.org'
                 },
@@ -87,6 +88,7 @@ module.exports = async function init() {
                     logo: 'https://www.globalforestwatch.org/packs/gfw-9c5fe396ee5b15cb5f5b639a7ef771bd.png',
                     principalColor: '#97be32',
                     sendNotifications: true,
+                    emailSender: 'noreply@globalforestwatch.org',
                     emailSenderName: 'GFW',
                     confirmUrlRedirect: 'https://www.globalforestwatch.org'
                 }

--- a/app/src/plugins/sd-ct-oauth-plugin/services/mail.service.js
+++ b/app/src/plugins/sd-ct-oauth-plugin/services/mail.service.js
@@ -18,6 +18,7 @@ function mailService(plugin) {
             const reqOpts = {
                 substitution_data: {
                     urlConfirm: `${this.publicUrl}/auth/confirm/${data.confirmationToken}`,
+                    fromEmail: generalConfig.application.emailSender,
                     fromName: generalConfig.application.emailSenderName,
                     appName: generalConfig.application.name,
                     logo: generalConfig.application.logo
@@ -52,6 +53,7 @@ function mailService(plugin) {
                 substitution_data: {
                     urlConfirm: `${this.publicUrl}/auth/confirm/${data.confirmationToken}?${data.callbackUrl ? `callbackUrl=${data.callbackUrl}` : ''}`,
                     password: data.password,
+                    fromEmail: generalConfig.application.emailSender,
                     fromName: generalConfig.application.emailSenderName,
                     appName: generalConfig.application.name,
                     logo: generalConfig.application.logo
@@ -85,6 +87,7 @@ function mailService(plugin) {
             const reqOpts = {
                 substitution_data: {
                     urlRecover: `${this.publicUrl}/auth/reset-password/${data.token}?origin=${originApp}`,
+                    fromEmail: generalConfig.application.emailSender,
                     fromName: generalConfig.application.emailSenderName,
                     appName: generalConfig.application.name,
                     logo: generalConfig.application.logo

--- a/app/test/e2e/ct-oauth/ct-oauth-recover-password-post-html.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-recover-password-post-html.spec.js
@@ -61,7 +61,6 @@ describe('OAuth endpoints tests - Recover password post - HTML version', () => {
             .type('form');
 
         return new Promise((resolve) => {
-
             response.status.should.equal(200);
             response.should.be.html;
             response.text.should.include(`Password and Repeat password are required`);

--- a/app/test/e2e/ct-oauth/ct-oauth-recover-password-post-json.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-recover-password-post-json.spec.js
@@ -154,7 +154,6 @@ describe('OAuth endpoints tests - Recover password post - JSON version', () => {
             response.redirects.should.be.an('array').and.length(0);
 
             const responseUser = response.body.data;
-            // eslint-disable-next-line no-unused-expressions
             responseUser.should.have.property('id').and.be.a('string').and.not.be.empty;
             responseUser.should.have.property('name').and.be.a('string').and.equal('lorem-ipsum');
             responseUser.should.have.property('photo').and.be.a('string').and.equal('http://www.random.rand/abc.jpg');

--- a/app/test/e2e/ct-oauth/ct-oauth-recover-password-request-html.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-recover-password-request-html.spec.js
@@ -27,23 +27,17 @@ describe('OAuth endpoints tests - Recover password request - HTML version', () =
 
         UserModel.deleteMany({}).exec();
         UserTempModel.deleteMany({}).exec();
-
-
     });
 
     beforeEach(async () => {
-
         UserModel.deleteMany({}).exec();
         UserTempModel.deleteMany({}).exec();
         RenewModel.deleteMany({}).exec();
-
-
     });
 
     it('Recover password request with no email should return an error - HTML format (TODO: this should return a 422)', async () => {
         const response = await requester
             .post(`/auth/reset-password`);
-
 
         response.status.should.equal(200);
         response.should.be.html;

--- a/app/test/e2e/ct-oauth/ct-oauth-recover-password-request-html.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-recover-password-request-html.spec.js
@@ -78,6 +78,7 @@ describe('OAuth endpoints tests - Recover password request - HTML version', () =
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'

--- a/app/test/e2e/ct-oauth/ct-oauth-recover-password-request-json.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-recover-password-request-json.spec.js
@@ -81,6 +81,7 @@ describe('OAuth endpoints tests - Recover password request - JSON version', () =
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'
@@ -137,6 +138,7 @@ describe('OAuth endpoints tests - Recover password request - JSON version', () =
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@globalforestwatch.org',
                         fromName: 'GFW',
                         appName: 'GFW',
                         logo: 'https://www.globalforestwatch.org/packs/gfw-9c5fe396ee5b15cb5f5b639a7ef771bd.png'

--- a/app/test/e2e/ct-oauth/ct-oauth-sign-up-with-auth.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-sign-up-with-auth.spec.js
@@ -107,6 +107,7 @@ describe('OAuth endpoints tests - Sign up with HTML UI', () => {
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'
@@ -230,6 +231,7 @@ describe('OAuth endpoints tests - Sign up with HTML UI', () => {
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'
@@ -293,6 +295,7 @@ describe('OAuth endpoints tests - Sign up with HTML UI', () => {
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@globalforestwatch.org',
                         fromName: 'GFW',
                         appName: 'GFW',
                         logo: 'https://www.globalforestwatch.org/packs/gfw-9c5fe396ee5b15cb5f5b639a7ef771bd.png'

--- a/app/test/e2e/ct-oauth/ct-oauth-sign-up-with-json-content-type.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-sign-up-with-json-content-type.spec.js
@@ -110,6 +110,7 @@ describe('OAuth endpoints tests - Sign up with JSON content type', () => {
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'
@@ -242,6 +243,7 @@ describe('OAuth endpoints tests - Sign up with JSON content type', () => {
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'

--- a/app/test/e2e/ct-oauth/ct-oauth-sign-up-without-auth.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-sign-up-without-auth.spec.js
@@ -97,6 +97,7 @@ describe('OAuth endpoints tests - Sign up without auth', () => {
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'
@@ -211,6 +212,7 @@ describe('OAuth endpoints tests - Sign up without auth', () => {
                         }
                     ],
                     substitution_data: {
+                        fromEmail: 'noreply@resourcewatch.org',
                         fromName: 'RW API',
                         appName: 'RW API',
                         logo: 'https://resourcewatch.org/static/images/logo-embed.png'

--- a/app/test/e2e/microservice-get.spec.js
+++ b/app/test/e2e/microservice-get.spec.js
@@ -1,5 +1,6 @@
 const nock = require('nock');
 const chai = require('chai');
+const config = require('config');
 
 const MicroserviceModel = require('models/microservice.model');
 const EndpointModel = require('models/endpoint.model');
@@ -60,7 +61,7 @@ describe('Microservices endpoints - GET endpoints', () => {
                 description: 'Control Tower - API',
                 version: '1.0.0'
             },
-            host: 'localhost:9000',
+            host: config.get('server.publicUrl').replace('http://', ''),
             schemes: [
                 'http'
             ],


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/168186665

## What does this PR add?

This PR adds configuration for the sender email when sending auth-related emails (when sending user confirmation email, user confirmation with password and password recovery). This value will be read from the oauth plugin configurations, using the `emailSender` key of each application.

**⚠️Before deploying to production:** update database config for oauth plugin to set the `emailSender` key in each application.

**⚠️After deploying to production:** update Sparkpost templates (confirm-user, confirm-user-with-password, recover-password) to use `fromEmail` instead of the current value.