### PR TITLE
Fix 500 error when trying to find users by ids providing invalid object ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 21/02/2020
+- Fix error when trying to find users by ids providing invalid object ids.
+
 # 14/02/2020
 - Remove `toDelete` from microservice model.
 - Add `createdAt` and `updatedAt` fields to the endpoint model.

--- a/app/src/plugins/sd-ct-oauth-plugin/services/auth.service.js
+++ b/app/src/plugins/sd-ct-oauth-plugin/services/auth.service.js
@@ -145,7 +145,7 @@ function authService(plugin, connection) {
         }
 
         static async getUsersByIds(ids = []) {
-            const newIds = ids.map((id) => new ObjectId(id));
+            const newIds = ids.filter(ObjectId.isValid).map((id) => new ObjectId(id));
             return UserModel.find({
                 _id: {
                     $in: newIds

--- a/app/test/e2e/ct-oauth/ct-oauth-find-by-ids.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-find-by-ids.spec.js
@@ -62,6 +62,16 @@ describe('Find users by id', () => {
         response.body.errors[0].should.have.property('detail').and.equal(`Ids objects required`);
     });
 
+    it('Find users with id list containing non-object ids returns an empty list (invalid ids are ignored)', async () => {
+        const response = await requester
+            .post(`/auth/user/find-by-ids`)
+            .set('Authorization', `Bearer ${TOKENS.MICROSERVICE}`)
+            .send({ ids: ['123'] });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(0);
+    });
+
     it('Find users with id list containing user that does not exist returns an empty list (empty db)', async () => {
         const response = await requester
             .post(`/auth/user/find-by-ids`)


### PR DESCRIPTION
This PR is related to the following task: https://www.pivotaltracker.com/story/show/169174283

When finding users by ids (using the endpoint `/auth/user/find-by-ids`), if by some reason an invalid (not a Mongoose ObjectId) id is provided (i.e. '123'), then a 500 Internal Server Error would be thrown. This PR adds filtering of the ids so that invalid ids are ignored when finding users by ids.