### PR TITLE
Read-only mode in CT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 01/04/2020
+- Add possibility of toggling a read-only mode that blocks all write endpoints.
+
 ## 21/02/2020
 - Fix error when trying to find users by ids providing invalid object ids.
 

--- a/app/src/loader.js
+++ b/app/src/loader.js
@@ -17,9 +17,7 @@ function getGeneralConfig() {
 async function loadPlugins(app) {
     logger.info('Loading plugins');
     const generalConfig = getGeneralConfig();
-    const plugins = await Plugin.find({
-        active: true,
-    });
+    const plugins = await Plugin.find({ active: true }).sort({ ordering: 1 });
     plugins.forEach((plugin) => {
         try {
             logger.info(`Loading ${plugin.name} plugin`);

--- a/app/src/migrations/init.js
+++ b/app/src/migrations/init.js
@@ -182,6 +182,7 @@ module.exports = async function init() {
             publicUrl: process.env.PUBLIC_URL,
             allowPublicRegistration: true
         },
+        ordering: 2,
     }).save();
 
     await new Plugin({
@@ -214,6 +215,7 @@ module.exports = async function init() {
             blacklist: [],
             whitelist: [],
         },
+        ordering: 1
     }).save();
 
     await Microservice.deleteMany({});

--- a/app/src/migrations/init.js
+++ b/app/src/migrations/init.js
@@ -205,6 +205,17 @@ module.exports = async function init() {
         },
     }).save();
 
+    await new Plugin({
+        name: 'readOnly',
+        description: 'Turn on/off read-only mode for CT, blocking writes to the database.',
+        mainFile: 'plugins/read-only',
+        active: false,
+        config: {
+            blacklist: [],
+            whitelist: [],
+        },
+    }).save();
+
     await Microservice.deleteMany({});
     await Endpoint.deleteMany({});
     await Version.deleteMany({});

--- a/app/src/models/plugin.model.js
+++ b/app/src/models/plugin.model.js
@@ -9,6 +9,7 @@ const Plugin = new Schema({
     cronFile: { type: String, required: false, trim: true },
     active: { type: Boolean, default: false },
     config: { type: Schema.Types.Mixed, required: false },
+    ordering: { type: Number, required: false, trim: true },
 });
 
 

--- a/app/src/plugins/read-only.js
+++ b/app/src/plugins/read-only.js
@@ -1,0 +1,23 @@
+const ReadOnlyService = require('../services/read-only.service');
+
+function init() {}
+
+function middleware(app, plugin) {
+    app.use(async (ctx, next) => {
+        const service = new ReadOnlyService(plugin.config.blacklist, plugin.config.whitelist);
+        const { method, path } = ctx.request;
+        if (service.shouldBlockRequest(method, path)) {
+            ctx.status = 503;
+            ctx.body = 'API under maintenance, please try again later.';
+            return;
+        }
+
+        await next();
+    });
+}
+
+
+module.exports = {
+    middleware,
+    init,
+};

--- a/app/src/services/read-only.service.js
+++ b/app/src/services/read-only.service.js
@@ -1,0 +1,29 @@
+module.exports = class ReadOnlyService {
+
+    constructor(blacklist = [], whitelist = []) {
+        this.blacklist = blacklist;
+        this.whitelist = whitelist;
+    }
+
+    isBlacklisted(path) {
+        return this.blacklist.includes(path);
+    }
+
+    isWhitelisted(path) {
+        return this.whitelist.includes(path);
+    }
+
+    shouldBlockRequest(method, path) {
+        return (ReadOnlyService.isRead(method) && this.isBlacklisted(path))
+        || (ReadOnlyService.isWrite(method) && !this.isWhitelisted(path));
+    }
+
+    static isRead(method) {
+        return method === 'GET';
+    }
+
+    static isWrite(method) {
+        return ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method);
+    }
+
+};

--- a/app/src/services/read-only.service.js
+++ b/app/src/services/read-only.service.js
@@ -19,7 +19,7 @@ module.exports = class ReadOnlyService {
     }
 
     static isRead(method) {
-        return method === 'GET';
+        return ['GET', 'OPTIONS', 'HEAD'].includes(method);
     }
 
     static isWrite(method) {

--- a/app/src/services/read-only.service.js
+++ b/app/src/services/read-only.service.js
@@ -6,11 +6,11 @@ module.exports = class ReadOnlyService {
     }
 
     isBlacklisted(path) {
-        return this.blacklist.includes(path);
+        return this.blacklist.some((element) => new RegExp(element).test(path));
     }
 
     isWhitelisted(path) {
-        return this.whitelist.includes(path);
+        return this.whitelist.some((element) => new RegExp(element).test(path));
     }
 
     shouldBlockRequest(method, path) {

--- a/app/test/e2e/read-only-mode.spec.js
+++ b/app/test/e2e/read-only-mode.spec.js
@@ -205,6 +205,42 @@ describe('Read-only mode spec', () => {
         deleteResult.text.should.equal('API under maintenance, please try again later.');
     });
 
+    it('Allows usage of Regex to define paths on blacklist', async () => {
+        await createCRUDEndpoints();
+        await setPluginSetting('readOnly', 'blacklist', ['.*dataset.*']);
+        requester = await getTestAgent(true);
+
+        const getResult = await requester.get('/api/v1/dataset');
+        getResult.status.should.equal(503);
+        getResult.text.should.equal('API under maintenance, please try again later.');
+    });
+
+    it('Allows usage of Regex to define paths on whitelist', async () => {
+        await createCRUDEndpoints();
+        await setPluginSetting('readOnly', 'whitelist', ['.*dataset.*']);
+        requester = await getTestAgent(true);
+
+        createMockEndpoint('/api/v1/dataset', { method: 'post' });
+        const postResult = await requester.post('/api/v1/dataset');
+        postResult.status.should.equal(200);
+        postResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'put' });
+        const putResult = await requester.put('/api/v1/dataset');
+        putResult.status.should.equal(200);
+        putResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'patch' });
+        const patchResult = await requester.patch('/api/v1/dataset');
+        patchResult.status.should.equal(200);
+        patchResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'delete' });
+        const deleteResult = await requester.delete('/api/v1/dataset');
+        deleteResult.status.should.equal(200);
+        deleteResult.text.should.equal('ok');
+    });
+
     afterEach(async () => {
         await UserModel.deleteMany({}).exec();
         await MicroserviceModel.deleteMany({}).exec();

--- a/app/test/e2e/read-only-mode.spec.js
+++ b/app/test/e2e/read-only-mode.spec.js
@@ -205,6 +205,31 @@ describe('Read-only mode spec', () => {
         deleteResult.text.should.equal('API under maintenance, please try again later.');
     });
 
+    it('Applies the same read-only criteria for CT authentication endpoints', async () => {
+        requester = await getTestAgent(true);
+
+        const { token } = await createUserAndToken({ role: 'ADMIN' });
+        const getResult = await requester
+            .get('/auth/user')
+            .set('Authorization', `Bearer ${token}`);
+        getResult.status.should.equal(200);
+        getResult.body.should.have.property('data');
+
+        const postResult = await requester
+            .post('/auth/user')
+            .set('Authorization', `Bearer ${token}`);
+        postResult.status.should.equal(503);
+        postResult.text.should.equal('API under maintenance, please try again later.');
+
+        const patchResult = await requester.patch('/auth/user');
+        patchResult.status.should.equal(503);
+        patchResult.text.should.equal('API under maintenance, please try again later.');
+
+        const deleteResult = await requester.delete('/auth/user');
+        deleteResult.status.should.equal(503);
+        deleteResult.text.should.equal('API under maintenance, please try again later.');
+    });
+
     it('Allows usage of Regex to define paths on blacklist', async () => {
         await createCRUDEndpoints();
         await setPluginSetting('readOnly', 'blacklist', ['.*dataset.*']);

--- a/app/test/e2e/read-only-mode.spec.js
+++ b/app/test/e2e/read-only-mode.spec.js
@@ -2,10 +2,11 @@ const nock = require('nock');
 
 const MicroserviceModel = require('models/microservice.model');
 const EndpointModel = require('models/endpoint.model');
+const Plugin = require('models/plugin.model');
 const UserModel = require('plugins/sd-ct-oauth-plugin/models/user.model');
 
 const { getTestAgent, closeTestAgent } = require('./test-server');
-const { createEndpoint } = require('./utils/helpers');
+const { createEndpoint, setPluginSetting } = require('./utils/helpers');
 const { createMockEndpoint } = require('./mock');
 
 let requester;
@@ -85,46 +86,32 @@ describe('Read-only mode spec', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        requester = await getTestAgent();
-
         await UserModel.deleteMany({}).exec();
         await MicroserviceModel.deleteMany({}).exec();
         await EndpointModel.deleteMany({}).exec();
-    });
 
-    it('By default, read-only mode is OFF and every request should be passed through (business as usual case)', async () => {
-        await createCRUDEndpoints();
+        // Create plugin if not it does not exist in the database
+        const existing = await Plugin.findOne({ name: 'readOnly' });
+        if (!existing) {
+            await new Plugin({
+                name: 'readOnly',
+                description: 'Turn on/off read-only mode for CT, blocking writes to the database.',
+                mainFile: 'plugins/read-only',
+                active: true,
+                config: {
+                    blacklist: [],
+                    whitelist: [],
+                },
+            }).save();
+        }
 
-        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'get' });
-        const getResult = await requester.get('/api/v1/dataset');
-        getResult.status.should.equal(200);
-        getResult.text.should.equal('ok');
-
-        createMockEndpoint('/api/v1/dataset', { method: 'post' });
-        const postResult = await requester.post('/api/v1/dataset');
-        postResult.status.should.equal(200);
-        postResult.text.should.equal('ok');
-
-        createMockEndpoint('/api/v1/dataset', { method: 'put' });
-        const putResult = await requester.put('/api/v1/dataset');
-        putResult.status.should.equal(200);
-        putResult.text.should.equal('ok');
-
-        createMockEndpoint('/api/v1/dataset', { method: 'patch' });
-        const patchResult = await requester.patch('/api/v1/dataset');
-        patchResult.status.should.equal(200);
-        patchResult.text.should.equal('ok');
-
-        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'delete' });
-        const deleteResult = await requester.delete('/api/v1/dataset');
-        deleteResult.status.should.equal(200);
-        deleteResult.text.should.equal('ok');
+        requester = await getTestAgent(true);
     });
 
     it('When read-only mode is ON, GET requests that are NOT blacklisted should be passed through', async () => {
         await createCRUDEndpoints();
-
-        // TODO: activate read only mode here
+        // await setPluginSetting('readOnly', 'local.confirmUrlRedirect', 'http://www.google.com/');
+        requester = await getTestAgent(true);
 
         createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'get' });
         const getResult = await requester.get('/api/v1/dataset');
@@ -134,25 +121,21 @@ describe('Read-only mode spec', () => {
 
     it('When read-only mode is ON, POST/PUT/PATCH/DELETE requests that are NOT whitelisted should return appropriate error message', async () => {
         await createCRUDEndpoints();
+        // await setPluginSetting('readOnly', 'local.confirmUrlRedirect', 'http://www.google.com/');
+        requester = await getTestAgent(true);
 
-        // TODO: activate read only mode here
-
-        createMockEndpoint('/api/v1/dataset', { method: 'post' });
         const postResult = await requester.post('/api/v1/dataset');
         postResult.status.should.equal(503);
         postResult.text.should.equal('API under maintenance, please try again later.');
 
-        createMockEndpoint('/api/v1/dataset', { method: 'put' });
         const putResult = await requester.put('/api/v1/dataset');
         putResult.status.should.equal(503);
         putResult.text.should.equal('API under maintenance, please try again later.');
 
-        createMockEndpoint('/api/v1/dataset', { method: 'patch' });
         const patchResult = await requester.patch('/api/v1/dataset');
         patchResult.status.should.equal(503);
         patchResult.text.should.equal('API under maintenance, please try again later.');
 
-        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'delete' });
         const deleteResult = await requester.delete('/api/v1/dataset');
         deleteResult.status.should.equal(503);
         deleteResult.text.should.equal('API under maintenance, please try again later.');
@@ -160,12 +143,9 @@ describe('Read-only mode spec', () => {
 
     it('When read-only mode is ON, GET requests that ARE blacklisted should return appropriate error message', async () => {
         await createCRUDEndpoints();
+        await setPluginSetting('readOnly', 'blacklist', ['/api/v1/dataset']);
+        requester = await getTestAgent(true);
 
-        // TODO: activate read only mode here
-
-        // TODO: add GET /api/v1/dataset to the black list
-
-        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'get' });
         const getResult = await requester.get('/api/v1/dataset');
         getResult.status.should.equal(503);
         getResult.text.should.equal('API under maintenance, please try again later.');
@@ -173,10 +153,8 @@ describe('Read-only mode spec', () => {
 
     it('When read-only mode is ON, POST/PUT/PATCH/DELETE requests that ARE whitelisted should be passed through', async () => {
         await createCRUDEndpoints();
-
-        // TODO: activate read only mode here
-
-        // TODO: add POST/PATCH/PUT/DELETE /api/v1/dataset to the white list
+        await setPluginSetting('readOnly', 'whitelist', ['/api/v1/dataset']);
+        requester = await getTestAgent(true);
 
         createMockEndpoint('/api/v1/dataset', { method: 'post' });
         const postResult = await requester.post('/api/v1/dataset');
@@ -209,5 +187,9 @@ describe('Read-only mode spec', () => {
         }
     });
 
-    after(closeTestAgent);
+    after(async () => {
+        await Plugin.deleteOne({ name: 'readOnly' });
+
+        closeTestAgent();
+    });
 });

--- a/app/test/e2e/read-only-mode.spec.js
+++ b/app/test/e2e/read-only-mode.spec.js
@@ -6,7 +6,7 @@ const Plugin = require('models/plugin.model');
 const UserModel = require('plugins/sd-ct-oauth-plugin/models/user.model');
 
 const { getTestAgent, closeTestAgent } = require('./test-server');
-const { createEndpoint, setPluginSetting } = require('./utils/helpers');
+const { createUserAndToken, createEndpoint, setPluginSetting } = require('./utils/helpers');
 const { createMockEndpoint } = require('./mock');
 
 let requester;
@@ -176,6 +176,33 @@ describe('Read-only mode spec', () => {
         const deleteResult = await requester.delete('/api/v1/dataset');
         deleteResult.status.should.equal(200);
         deleteResult.text.should.equal('ok');
+    });
+
+    it('Applies the same read-only criteria for CT endpoints', async () => {
+        requester = await getTestAgent(true);
+
+        const { token } = await createUserAndToken({ role: 'ADMIN' });
+        const getResult = await requester
+            .get('/api/v1/microservice')
+            .set('Authorization', `Bearer ${token}`);
+        getResult.status.should.equal(200);
+        getResult.text.should.equal('[]');
+
+        const postResult = await requester.post('/api/v1/microservice');
+        postResult.status.should.equal(503);
+        postResult.text.should.equal('API under maintenance, please try again later.');
+
+        const putResult = await requester.put('/api/v1/microservice');
+        putResult.status.should.equal(503);
+        putResult.text.should.equal('API under maintenance, please try again later.');
+
+        const patchResult = await requester.patch('/api/v1/microservice');
+        patchResult.status.should.equal(503);
+        patchResult.text.should.equal('API under maintenance, please try again later.');
+
+        const deleteResult = await requester.delete('/api/v1/microservice');
+        deleteResult.status.should.equal(503);
+        deleteResult.text.should.equal('API under maintenance, please try again later.');
     });
 
     afterEach(async () => {

--- a/app/test/e2e/read-only-mode.spec.js
+++ b/app/test/e2e/read-only-mode.spec.js
@@ -110,7 +110,6 @@ describe('Read-only mode spec', () => {
 
     it('When read-only mode is ON, GET requests that are NOT blacklisted should be passed through', async () => {
         await createCRUDEndpoints();
-        // await setPluginSetting('readOnly', 'local.confirmUrlRedirect', 'http://www.google.com/');
         requester = await getTestAgent(true);
 
         createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'get' });
@@ -121,7 +120,6 @@ describe('Read-only mode spec', () => {
 
     it('When read-only mode is ON, POST/PUT/PATCH/DELETE requests that are NOT whitelisted should return appropriate error message', async () => {
         await createCRUDEndpoints();
-        // await setPluginSetting('readOnly', 'local.confirmUrlRedirect', 'http://www.google.com/');
         requester = await getTestAgent(true);
 
         const postResult = await requester.post('/api/v1/dataset');

--- a/app/test/e2e/read-only-mode.spec.js
+++ b/app/test/e2e/read-only-mode.spec.js
@@ -1,0 +1,213 @@
+const nock = require('nock');
+
+const MicroserviceModel = require('models/microservice.model');
+const EndpointModel = require('models/endpoint.model');
+const UserModel = require('plugins/sd-ct-oauth-plugin/models/user.model');
+
+const { getTestAgent, closeTestAgent } = require('./test-server');
+const { createEndpoint } = require('./utils/helpers');
+const { createMockEndpoint } = require('./mock');
+
+let requester;
+
+const createCRUDEndpoints = async () => Promise.all([
+    createEndpoint({
+        path: '/v1/dataset',
+        method: 'GET',
+        redirect: [
+            {
+                microservice: 'dataset',
+                filters: null,
+                method: 'GET',
+                path: '/api/v1/dataset',
+                url: 'http://mymachine:6001'
+            }
+        ],
+    }),
+    createEndpoint({
+        path: '/v1/dataset',
+        method: 'POST',
+        redirect: [
+            {
+                microservice: 'dataset',
+                filters: null,
+                method: 'POST',
+                path: '/api/v1/dataset',
+                url: 'http://mymachine:6001'
+            }
+        ],
+    }),
+    createEndpoint({
+        path: '/v1/dataset',
+        method: 'PUT',
+        redirect: [
+            {
+                microservice: 'dataset',
+                filters: null,
+                method: 'PUT',
+                path: '/api/v1/dataset',
+                url: 'http://mymachine:6001'
+            }
+        ],
+    }),
+    createEndpoint({
+        path: '/v1/dataset',
+        method: 'PATCH',
+        redirect: [
+            {
+                microservice: 'dataset',
+                filters: null,
+                method: 'PATCH',
+                path: '/api/v1/dataset',
+                url: 'http://mymachine:6001'
+            }
+        ],
+    }),
+    createEndpoint({
+        path: '/v1/dataset',
+        method: 'DELETE',
+        redirect: [
+            {
+                microservice: 'dataset',
+                filters: null,
+                method: 'DELETE',
+                path: '/api/v1/dataset',
+                url: 'http://mymachine:6001'
+            }
+        ],
+    })
+]);
+
+describe('Read-only mode spec', () => {
+
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestAgent();
+
+        await UserModel.deleteMany({}).exec();
+        await MicroserviceModel.deleteMany({}).exec();
+        await EndpointModel.deleteMany({}).exec();
+    });
+
+    it('By default, read-only mode is OFF and every request should be passed through (business as usual case)', async () => {
+        await createCRUDEndpoints();
+
+        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'get' });
+        const getResult = await requester.get('/api/v1/dataset');
+        getResult.status.should.equal(200);
+        getResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'post' });
+        const postResult = await requester.post('/api/v1/dataset');
+        postResult.status.should.equal(200);
+        postResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'put' });
+        const putResult = await requester.put('/api/v1/dataset');
+        putResult.status.should.equal(200);
+        putResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'patch' });
+        const patchResult = await requester.patch('/api/v1/dataset');
+        patchResult.status.should.equal(200);
+        patchResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'delete' });
+        const deleteResult = await requester.delete('/api/v1/dataset');
+        deleteResult.status.should.equal(200);
+        deleteResult.text.should.equal('ok');
+    });
+
+    it('When read-only mode is ON, GET requests that are NOT blacklisted should be passed through', async () => {
+        await createCRUDEndpoints();
+
+        // TODO: activate read only mode here
+
+        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'get' });
+        const getResult = await requester.get('/api/v1/dataset');
+        getResult.status.should.equal(200);
+        getResult.text.should.equal('ok');
+    });
+
+    it('When read-only mode is ON, POST/PUT/PATCH/DELETE requests that are NOT whitelisted should return appropriate error message', async () => {
+        await createCRUDEndpoints();
+
+        // TODO: activate read only mode here
+
+        createMockEndpoint('/api/v1/dataset', { method: 'post' });
+        const postResult = await requester.post('/api/v1/dataset');
+        postResult.status.should.equal(503);
+        postResult.text.should.equal('API under maintenance, please try again later.');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'put' });
+        const putResult = await requester.put('/api/v1/dataset');
+        putResult.status.should.equal(503);
+        putResult.text.should.equal('API under maintenance, please try again later.');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'patch' });
+        const patchResult = await requester.patch('/api/v1/dataset');
+        patchResult.status.should.equal(503);
+        patchResult.text.should.equal('API under maintenance, please try again later.');
+
+        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'delete' });
+        const deleteResult = await requester.delete('/api/v1/dataset');
+        deleteResult.status.should.equal(503);
+        deleteResult.text.should.equal('API under maintenance, please try again later.');
+    });
+
+    it('When read-only mode is ON, GET requests that ARE blacklisted should return appropriate error message', async () => {
+        await createCRUDEndpoints();
+
+        // TODO: activate read only mode here
+
+        // TODO: add GET /api/v1/dataset to the black list
+
+        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'get' });
+        const getResult = await requester.get('/api/v1/dataset');
+        getResult.status.should.equal(503);
+        getResult.text.should.equal('API under maintenance, please try again later.');
+    });
+
+    it('When read-only mode is ON, POST/PUT/PATCH/DELETE requests that ARE whitelisted should be passed through', async () => {
+        await createCRUDEndpoints();
+
+        // TODO: activate read only mode here
+
+        // TODO: add POST/PATCH/PUT/DELETE /api/v1/dataset to the white list
+
+        createMockEndpoint('/api/v1/dataset', { method: 'post' });
+        const postResult = await requester.post('/api/v1/dataset');
+        postResult.status.should.equal(200);
+        postResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'put' });
+        const putResult = await requester.put('/api/v1/dataset');
+        putResult.status.should.equal(200);
+        putResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset', { method: 'patch' });
+        const patchResult = await requester.patch('/api/v1/dataset');
+        patchResult.status.should.equal(200);
+        patchResult.text.should.equal('ok');
+
+        createMockEndpoint('/api/v1/dataset?loggedUser=null', { method: 'delete' });
+        const deleteResult = await requester.delete('/api/v1/dataset');
+        deleteResult.status.should.equal(200);
+        deleteResult.text.should.equal('ok');
+    });
+
+    afterEach(async () => {
+        await UserModel.deleteMany({}).exec();
+        await MicroserviceModel.deleteMany({}).exec();
+        await EndpointModel.deleteMany({}).exec();
+
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+    });
+
+    after(closeTestAgent);
+});

--- a/app/test/e2e/read-only-mode.spec.js
+++ b/app/test/e2e/read-only-mode.spec.js
@@ -103,6 +103,9 @@ describe('Read-only mode spec', () => {
                     whitelist: [],
                 },
             }).save();
+        } else {
+            existing.active = true;
+            await existing.save();
         }
 
         requester = await getTestAgent(true);


### PR DESCRIPTION
This PR implements the possibility of "locking-down" CT to a **read-only (RO)** mode, where all endpoints that interact with data are rejected with a 503 Service Unavailable HTTP status.

The default behavior of this RO mode is **OFF**, and when activated, it should allow all GET calls to keep being fulfilled, while POST/PATCH/PUT/DELETE calls are rejected with status 503.

This includes also the possibility of **blacklisting** GET endpoints that should also be rejected, as well as **whitelisting** POST/PATCH/PUT/DELETE endpoints that should keep being fulfilled.

Associated docs PR: https://github.com/resource-watch/doc-api/pull/136