### PR TITLE
Upgrade usages of Facebook Graph API to v7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.4.1
+
+## 13/07/2020
+
+- Update version used of Facebook Graph API to 7.0 in Facebook OAuth.
+
 # 2.4.0
 
 ## 25/06/2020

--- a/app/src/plugins/sd-ct-oauth-plugin/services/passport.service.js
+++ b/app/src/plugins/sd-ct-oauth-plugin/services/passport.service.js
@@ -181,7 +181,8 @@ function passportService(plugin) {
                     clientID: app.facebook.clientID,
                     clientSecret: app.facebook.clientSecret,
                     callbackURL: `${plugin.config.publicUrl}/auth/facebook/callback`,
-                    profileFields: ['id', 'displayName', 'photos', 'email']
+                    profileFields: ['id', 'displayName', 'photos', 'email'],
+                    graphAPIVersion: 'v7.0',
                 };
                 const facebookStrategy = new FacebookStrategy(configFacebook, registerUser);
                 facebookStrategy.name += `:${apps[i]}`;

--- a/app/test/e2e/ct-oauth/ct-oauth-facebook.spec.js
+++ b/app/test/e2e/ct-oauth/ct-oauth-facebook.spec.js
@@ -55,7 +55,7 @@ describe('Facebook auth endpoint tests', () => {
 
         const response = await requester.get(`/auth/facebook`).redirects(0);
         response.should.redirect;
-        response.should.redirectTo(/^https:\/\/www\.facebook\.com\/v3.2\/dialog\/oauth/);
+        response.should.redirectTo(/^https:\/\/www\.facebook\.com\/v7\.0\/dialog\/oauth/);
     });
 
     it('Visiting /auth/facebook/callback while being logged in should redirect to the login successful page', async () => {
@@ -67,7 +67,7 @@ describe('Facebook auth endpoint tests', () => {
         should.not.exist(missingUser);
 
         nock('https://graph.facebook.com')
-            .post('/v3.2/oauth/access_token', {
+            .post('/v7.0/oauth/access_token', {
                 grant_type: 'authorization_code',
                 redirect_uri: `${process.env.PUBLIC_URL}/auth/facebook/callback`,
                 client_id: process.env.TEST_FACEBOOK_OAUTH2_APP_ID,
@@ -82,7 +82,7 @@ describe('Facebook auth endpoint tests', () => {
 
 
         nock('https://graph.facebook.com')
-            .get('/v3.2/me')
+            .get('/v7.0/me')
             .query({
                 fields: 'id,name,picture,email',
                 access_token: 'facebook_access_token'
@@ -131,7 +131,7 @@ describe('Facebook auth endpoint tests', () => {
         should.not.exist(missingUser);
 
         nock('https://graph.facebook.com')
-            .post('/v3.2/oauth/access_token', {
+            .post('/v7.0/oauth/access_token', {
                 grant_type: 'authorization_code',
                 redirect_uri: `${process.env.PUBLIC_URL}/auth/facebook/callback`,
                 client_id: process.env.TEST_FACEBOOK_OAUTH2_APP_ID,
@@ -146,7 +146,7 @@ describe('Facebook auth endpoint tests', () => {
 
 
         nock('https://graph.facebook.com')
-            .get('/v3.2/me')
+            .get('/v7.0/me')
             .query({
                 fields: 'id,name,picture,email',
                 access_token: 'facebook_access_token'
@@ -206,7 +206,7 @@ describe('Facebook auth endpoint tests', () => {
         should.not.exist(missingUser);
 
         nock('https://graph.facebook.com')
-            .post('/v3.2/oauth/access_token', {
+            .post('/v7.0/oauth/access_token', {
                 grant_type: 'authorization_code',
                 redirect_uri: `${process.env.PUBLIC_URL}/auth/facebook/callback`,
                 client_id: process.env.TEST_FACEBOOK_OAUTH2_APP_ID,
@@ -221,7 +221,7 @@ describe('Facebook auth endpoint tests', () => {
 
 
         nock('https://graph.facebook.com')
-            .get('/v3.2/me')
+            .get('/v7.0/me')
             .query({
                 fields: 'id,name,picture,email',
                 access_token: 'facebook_access_token'

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "mongoose-paginate": "^5.0.3",
     "mongoose-regexp": "^0.0.1",
     "passport-facebook": "^3.0.0",
-    "passport-facebook-token": "3.3.0",
+    "passport-facebook-token": "^4.0.0",
     "passport-google-oauth20": "^1.0.0",
     "passport-google-token": "^0.1.2",
     "passport-http": "^0.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5106,10 +5106,10 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-passport-facebook-token@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/passport-facebook-token/-/passport-facebook-token-3.3.0.tgz#7404ca6fdd3790e11060cc60c562b21f0d0481ee"
-  integrity sha1-dATKb903kOEQYMxgxWKyHw0Ege4=
+passport-facebook-token@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/passport-facebook-token/-/passport-facebook-token-4.0.0.tgz#3b75c4ad4af338b6e20ac829d712866fc82b2f4b"
+  integrity sha512-QihlU3xphIVDvhko1e2pfLZfIyLnjIgSO2CVtlas0QNv3484atvfQLs+3WoXSkG70KEV/nhD5Dkki/QGqsHeMA==
   dependencies:
     passport-oauth "1.0.0"
 


### PR DESCRIPTION
This PR relates to the following JIRA issue: https://gfw.atlassian.net/browse/GTC-654

This PR updates all usages of Facebook Graph API to version 7.0, in an effort to remove all usages of deprecated API versions across the API.