### PR TITLE
Require grunt-contrib-watch and grunt-express-server so local docker …

### DIFF
--- a/app/Gruntfile.js
+++ b/app/Gruntfile.js
@@ -111,10 +111,13 @@ module.exports = (grunt) => {
 
     grunt.registerTask('test', ['e2eTest']);
 
+    grunt.loadNpmTasks('grunt-express-server');
+
     grunt.registerTask('serve', ['express:dev', 'watch']);
     grunt.registerTask('crons', ['express:cron', 'watch']);
 
     grunt.registerTask('default', 'serve');
 
     grunt.loadNpmTasks('grunt-simple-nyc');
+    grunt.loadNpmTasks('grunt-contrib-watch');
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "eslint-plugin-react": "^7.21.5",
     "grunt": "^1.3.0",
     "grunt-cli": "^1.3.2",
+    "grunt-contrib-watch": "^1.1.0",
+    "grunt-express-server": "0.5.4",
     "grunt-mocha-test": "^0.13.3",
     "grunt-simple-nyc": "^3.0.1",
     "husky": "^4.3.5",


### PR DESCRIPTION
This PR is just to ensure that the local docker environment works. Currently running `./controlTower.sh develop` on a fresh clone throws errors.

The docker environment uses grunt to run a number of tasks but the following dependencies were missing:

- grunt-contrib-watch
- grunt-express-server

I also then needed to load the relevant npm tasks within the `Grunt.file` in order for grunt to work.

@tiagojsag - I see you are active on this repo so I will direct the PR to you, if you do not mind? 

I believe grunt is only used locally, and this change will not affect staging or production, pelase could you confirm.
